### PR TITLE
fix: postinstall script

### DIFF
--- a/cmd/use_correct_pm.go
+++ b/cmd/use_correct_pm.go
@@ -13,7 +13,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:     "use-correct-pm",
-	Version: "1.0.0",
+	Version: "1.0.1",
 	Short:   "A simple check of the usage of the correct package manager",
 	Long: `Check if the correct package manager is used.
 Available are 'NPM', 'Yarn' and 'PNPM'.`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "use-correct-pm",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A simple check of the usage of the correct package manager.",
 	"keywords": [
 		"package-manager",
@@ -16,7 +16,7 @@
 	"license": "MIT",
 	"author": "Alexander Böhm <tools@boehm.work>",
 	"scripts": {
-		"postinstall": "'is-ci || go-npm install'",
+		"postinstall": "is-ci || go-npm install",
 		"prepare": "husky install",
 		"sort-package-json": "pnpm dlx sort-package-json",
 		"preuninstall": "go-npm uninstall"


### PR DESCRIPTION
The postinstall script in the `package.json` was set as a string. It is fixed now.